### PR TITLE
Added virtualenv indicator to preprompt

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -156,6 +156,11 @@ prompt_pure_preprompt_render() {
 	pp="%~"
 	preprompt+=("%F{blue}$pp%f")
 
+	# virtualenv
+	if [[ -n "$VIRTUAL_ENV" ]]; then
+		preprompt+=("%F{green}venv:${VIRTUAL_ENV:t}%f")
+	fi
+
 	# git info
 	if (( ${+prompt_pure_vcs[working_tree]} && ! ${+prompt_pure_vcs[unsure]} )); then
 		# branch and action


### PR DESCRIPTION
Would you consider adding to preprompt indication of active python virtualenv? It's plain simple and wouldn't slowdown the rendering of preprompt.

Original `pure` project is going back and forth with this, so I decided to check would you be interested in inclusion of this feature? Personally I'm using this fork too. But there is no proper way to extend preprompt with my own entries, so I have to [mess around](https://github.com/z0rc/dotfiles/blob/master/zsh/zshrc#L122-L132) with prompt in my own precmd hook. This approach is a suboptimal.  Native support would be welcome and much simpler, hence here is this PR.

This is how it looks like in action: 
![screenshot_20161115_001330](https://cloud.githubusercontent.com/assets/787519/20285041/7c128630-aac8-11e6-9052-89c0da08b8fb.png)
